### PR TITLE
Optimize CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           coverage.out
         retention-days: 30
 
-  # Stage 2: Comprehensive testing in parallel
+  # Stage 2: Comprehensive testing (runs in parallel after lint passes)
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
@@ -79,13 +79,8 @@ jobs:
     - name: Download dependencies
       run: go mod download
 
-    - name: Set up envtest binaries
-      run: make setup-envtest
-
     - name: Run integration tests
-      run: |
-        source test/envtest/env.sh
-        make test-integration
+      run: make test-integration
 
     - name: Upload integration test results
       uses: actions/upload-artifact@v5


### PR DESCRIPTION
Fixes #11

Coverage job is not needed in this phase and adds unnecessary CI time. Tests now run in parallel after lint passes using automatic envtest discovery.